### PR TITLE
Fix participant name persistence for video session guests

### DIFF
--- a/client/src/pages/JoinSession.tsx
+++ b/client/src/pages/JoinSession.tsx
@@ -49,11 +49,12 @@ export default function JoinSession() {
 
       if (response.success) {
         // Store session info for video component
+        sessionStorage.setItem('participantName', name.trim());
         sessionStorage.setItem('videoSession', JSON.stringify({
           authToken: response.authToken,
           roomId: response.roomId,
           sessionId: response.sessionId,
-          userName: name,
+          userName: name.trim(),
           role: 'participant'
         }));
 

--- a/client/src/pages/VideoSession.tsx
+++ b/client/src/pages/VideoSession.tsx
@@ -25,7 +25,12 @@ export default function VideoSession() {
   const [connectionError, setConnectionError] = useState<VideoError | null>(null);
 
   // Get participant name from sessionStorage (set by JoinSession page for guests)
-  const participantName = sessionStorage.getItem('participantName') || user?.firstName || 'Guest';
+  const storedSession = sessionStorage.getItem('videoSession');
+  const parsedSession = storedSession ? JSON.parse(storedSession) : null;
+  const participantName = parsedSession?.userName
+    || sessionStorage.getItem('participantName')
+    || user?.firstName
+    || 'Guest';
 
   // Get session details
   const { data: sessionData, isLoading, error } = useQuery({


### PR DESCRIPTION
## Summary
- persist participant name when joining sessions as a guest
- read stored guest session details so the video session uses the correct display name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239e089ed483279a861abb66c3536e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist trimmed participant name on join and prefer stored `videoSession.userName` (with fallbacks) for display in the video session.
> 
> - **Client**:
>   - `client/src/pages/JoinSession.tsx`:
>     - Store `participantName` and save trimmed `userName` in `sessionStorage` `videoSession` payload.
>   - `client/src/pages/VideoSession.tsx`:
>     - Resolve display name by reading `parsedSession.userName` from `sessionStorage` `videoSession`, falling back to `participantName`, `user.firstName`, then `Guest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27cfa45f79d6e762cc7b804a65f1c160c13abc80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->